### PR TITLE
Fix #8: Generated type of expect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as mock from 'jest-mock';
 
 export const { jest } = instrument({ jest: mock });
 
-export const { expect } = instrument(
+export const expect: typeof expectPatched = instrument(
   { expect: expectPatched },
   { intercept: (method, path) => path[0] !== 'expect' }
-);
+).expect;


### PR DESCRIPTION
Declaring the type explicitly seems to fix the generated type definitions.

With this change, `index.d.ts` generates as:

```
import { default as expectPatched } from '@storybook/expect';
import * as mock from 'jest-mock';
export declare const jest: typeof mock;
export declare const expect: typeof expectPatched;
```

instead of as

```
import * as mock from 'jest-mock';
export declare const jest: typeof mock;
export declare const expect: import("expect/build/types").Expect<import("expect/build/types").MatcherState>;
```

This prevents the typescript-eslint errors reported on #8. 