### PR TITLE
Filter invalid matchers before extending expect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ const expect: typeof expectPatched = instrument(
   { intercept: (_method, path) => path[0] !== 'expect' }
 ).expect;
 
+// @TODO: This should be reverted once https://github.com/testing-library/jest-dom/pull/438 is merged
 // Some bundlers include an undefined `default` in the namespace import,
 // or __esmodule (a boolean) which cause expect.extend to throw.
 const validMatchers = { ...matchers };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,16 @@ const expect: typeof expectPatched = instrument(
   { intercept: (_method, path) => path[0] !== 'expect' }
 ).expect;
 
-expect.extend(matchers);
+// Some bundlers include an undefined `default` in the namespace import,
+// or __esmodule (a boolean) which cause expect.extend to throw.
+const validMatchers = { ...matchers };
+Object.keys(validMatchers).forEach((matcherName) => {
+  const matcher = validMatchers[matcherName];
+  if (typeof matcher === 'undefined' || typeof matcher === 'boolean') {
+    delete validMatchers[matcherName];
+  }
+});
+
+expect.extend(validMatchers);
 
 export { expect, jest };


### PR DESCRIPTION
## Change Type

Closes #15

This fixes @storybook/jest for vite projects, by removing the `__esmodule` and `default` properties (and anything else that isn't a valid matcher type, or at least that's undefined or boolean) before extending expect.

I've tested this in my own vite project by copying the build file into my node_modules, and it worked as expected.  It would be good to double-check in a webpack project as well, though.

This should only be needed until/unless https://github.com/testing-library/jest-dom/pull/438 is released and can be used.

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.10--canary.16.6472401.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/jest@0.0.10--canary.16.6472401.0
  # or 
  yarn add @storybook/jest@0.0.10--canary.16.6472401.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
