### PR TITLE
Support storybook 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,21 +25,25 @@
   },
   "dependencies": {
     "@storybook/expect": "storybook-jest",
-    "@storybook/instrumenter": "^6.4.0",
+    "@storybook/instrumenter": "next",
     "@testing-library/jest-dom": "^5.16.2",
     "jest-mock": "^27.3.0"
   },
   "devDependencies": {
-    "@auto-it/first-time-contributor": "^10.32.6",
-    "@auto-it/released": "^10.32.6",
+    "@auto-it/first-time-contributor": "^10.37.6",
+    "@auto-it/released": "^10.37.6",
     "@storybook/linter-config": "^3.1.2",
     "@types/react": "*",
-    "auto": "^10.32.6",
+    "auto": "^10.37.6",
     "expect": "^27.3.1",
     "typescript": "^4.4.3"
   },
   "author": "yannbf@gmail.com",
   "auto": {
+    "prereleaseBranches": [
+      "next",
+      "prerelease"
+    ],
     "plugins": [
       "npm",
       "first-time-contributor",


### PR DESCRIPTION
This PR introduces a new prerelease strategy and Storybook 7.0 support for the next version of this library
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.11--canary.22.2783ae7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/jest@0.0.11--canary.22.2783ae7.0
  # or 
  yarn add @storybook/jest@0.0.11--canary.22.2783ae7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
