### PR TITLE
Change build scripts to use tsup instead of tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release": "auto shipit"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "license": "MIT",
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release": "auto shipit"
   },
   "main": "./dist/index.js",
-  "module": "./dist/index.,js",
+  "module": "./dist/index.js",
   "license": "MIT",
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -7,19 +7,17 @@
     "url": "https://github.com/storybookjs/jest.git"
   },
   "scripts": {
-    "build": "yarn build:esm && yarn build:cjs",
-    "build:esm": "tsc --project tsconfig.esm.json",
-    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build": "tsup ./src/index.ts --format cjs,esm --dts",
     "prerelease": "yarn build",
     "release": "auto shipit"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.,js",
   "license": "MIT",
   "files": [
     "dist/**/*"
   ],
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
@@ -31,12 +29,13 @@
   },
   "devDependencies": {
     "@auto-it/first-time-contributor": "^10.37.6",
+    "tsup": "^5.12.0",
     "@auto-it/released": "^10.37.6",
     "@storybook/linter-config": "^3.1.2",
     "@types/react": "*",
     "auto": "^10.37.6",
     "expect": "^27.3.1",
-    "typescript": "^4.4.3"
+    "typescript": "^5.0.4"
   },
   "author": "yannbf@gmail.com",
   "auto": {

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "./dist/cjs",
-    "module": "CommonJS",
-  },
-}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,9 +1,0 @@
-
-{
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "./dist/esm",
-    "module": "ES6",
-    "target": "ES5",
-  },
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "noImplicitAny": true,
-    "allowJs": true,
+    "strict": true,
+    "target": "es2020",
+    "module": "ESNext",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "declaration": true,


### PR DESCRIPTION
## Change Type

Indicate the type of change your pull request is:

- [x] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1--canary.26.df816e6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/jest@0.1.1--canary.26.df816e6.0
  # or 
  yarn add @storybook/jest@0.1.1--canary.26.df816e6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
