### PR TITLE
Fix: Make sure that expect matches the runtime type when instrumented

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "@storybook/expect": "storybook-jest",
     "@testing-library/jest-dom": "^5.16.2",
-    "jest-mock": "^27.3.0"
+    "jest-mock": "^27.3.0",
+    "@types/jest": "28.1.3"
   },
   "devDependencies": {
     "@auto-it/first-time-contributor": "^10.37.6",
@@ -34,6 +35,7 @@
     "auto": "^10.37.6",
     "util": "^0.12.5",
     "expect": "^27.3.1",
+    "prettier": "^2.8.8",
     "tsup": "^5.12.0",
     "typescript": "^5.0.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,18 @@ import { default as expectPatched } from '@storybook/expect';
 import { instrument } from '@storybook/instrumenter';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import * as mock from 'jest-mock';
-
 const { jest } = instrument({ jest: mock });
 
-const expect: typeof expectPatched = instrument(
+export type Expect = {
+  [P in keyof jest.Expect]: jest.Expect[P];
+} & (<T = any>(
+  actual: T
+) => jest.JestMatchersShape<jest.Matchers<Promise<void>, T>, jest.Matchers<Promise<void>, T>>);
+
+const expect = instrument(
   { expect: expectPatched },
   { intercept: (_method, path) => path[0] !== 'expect' }
-).expect;
+).expect as unknown as Expect;
 
 // @TODO: This should be reverted once https://github.com/testing-library/jest-dom/pull/438 is merged
 // Some bundlers include an undefined `default` in the namespace import,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,25 @@ import { default as expectPatched } from '@storybook/expect';
 import { instrument } from '@storybook/instrumenter';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import * as mock from 'jest-mock';
+
 const { jest } = instrument({ jest: mock });
 
-export type Expect = {
-  [P in keyof jest.Expect]: jest.Expect[P];
-} & (<T = any>(
-  actual: T
-) => jest.JestMatchersShape<jest.Matchers<Promise<void>, T>, jest.Matchers<Promise<void>, T>>);
+/**
+ * The `expect` function is used every time you want to test a value.
+ * You will rarely call `expect` by itself.
+ */
+export interface Expect extends Pick<jest.Expect, keyof jest.Expect> {
+  /**
+   * The `expect` function is used every time you want to test a value.
+   * You will rarely call `expect` by itself.
+   *
+   * @param actual The value to apply matchers against.
+   */
+  <T = any>(actual: T): jest.JestMatchersShape<
+    jest.Matchers<Promise<void>, T>,
+    jest.Matchers<Promise<void>, T>
+  >;
+}
 
 const expect = instrument(
   { expect: expectPatched },


### PR DESCRIPTION
Closes https://github.com/storybookjs/jest/issues/32

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

This is a fix, but also in some sense a breaking change... 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.0--canary.34.b637a39.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/jest@0.2.0--canary.34.b637a39.0
  # or 
  yarn add @storybook/jest@0.2.0--canary.34.b637a39.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
