### PR TITLE
Fix cjs/esm interoperability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,9 @@ const expect = instrument(
   { intercept: (_method, path) => path[0] !== 'expect' }
 ).expect as unknown as Expect;
 
-expect.extend(matchers);
+
+// This is a workaround needed for CJS/ESM interop, to make both Vite and Webpack work, in CJS and ESM, without warnings.
+const name = 'default' // we need to trick Webpack, this is how 🎉
+expect.extend(matchers?.[name] ?? matchers);
 
 export { expect, jest };


### PR DESCRIPTION
Closes #45

## Contributor's checklist:

### What I did

See #45 for details. This PR adds a workaround for CJS/ESM to work in tandem

### Change type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Maintainer's checklist:

- [ ] Make sure to define a release label corresponding to what the contributor selected above.
- [ ] If this PR should not trigger a release, label it as `skip-release`.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.3--canary.47.6408412468.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/jest@0.2.3--canary.47.6408412468.0
  # or 
  yarn add @storybook/jest@0.2.3--canary.47.6408412468.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
