### PR TITLE
Update `@testing-library/jest-dom` to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@storybook/expect": "storybook-jest",
-    "@testing-library/jest-dom": "^6.1.2",
+    "@testing-library/jest-dom": "^6.1.6",
     "@types/jest": "28.1.3",
     "jest-mock": "^27.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@adobe/css-tools@npm:^4.3.0":
-  version: 4.3.1
-  resolution: "@adobe/css-tools@npm:4.3.1"
-  checksum: ad43456379ff391132aff687ece190cb23ea69395e23c9b96690eeabe2468da89a4aaf266e4f8b6eaab53db3d1064107ce0f63c3a974e864f4a04affc768da3f
+"@adobe/css-tools@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@adobe/css-tools@npm:4.3.2"
+  checksum: 9667d61d55dc3b0a315c530ae84e016ce5267c4dd8ac00abb40108dc98e07b98e3090ce8b87acd51a41a68d9e84dcccb08cdf21c902572a9cf9dcaf830da4ae3
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
     "@storybook/expect": storybook-jest
     "@storybook/instrumenter": next
     "@storybook/linter-config": ^3.1.2
-    "@testing-library/jest-dom": ^6.1.2
+    "@testing-library/jest-dom": ^6.1.6
     "@types/jest": 28.1.3
     "@types/react": "*"
     auto: ^10.37.6
@@ -700,16 +700,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^6.1.2":
-  version: 6.1.2
-  resolution: "@testing-library/jest-dom@npm:6.1.2"
+"@testing-library/jest-dom@npm:^6.1.6":
+  version: 6.2.0
+  resolution: "@testing-library/jest-dom@npm:6.2.0"
   dependencies:
-    "@adobe/css-tools": ^4.3.0
+    "@adobe/css-tools": ^4.3.2
     "@babel/runtime": ^7.9.2
     aria-query: ^5.0.0
     chalk: ^3.0.0
     css.escape: ^1.5.1
-    dom-accessibility-api: ^0.5.6
+    dom-accessibility-api: ^0.6.3
     lodash: ^4.17.15
     redent: ^3.0.0
   peerDependencies:
@@ -726,7 +726,7 @@ __metadata:
       optional: true
     vitest:
       optional: true
-  checksum: de6b7f98d1b42887192eb70fd917b2b98d92aab22a86801718de75e0ca4964589335efeb650b0f7b9859609446b20d2bd81bfc5755f1655885d5664d1c093a70
+  checksum: 3d46e36b1b7c2cb3c92f64d55d458aab44ae135ac77299df14d14dcf567a286590de58b2f140011b8f7a343f0703ff88f144f27c6ae4921fd612741771d8ee2c
   languageName: node
   linkType: hard
 
@@ -2100,10 +2100,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:^0.5.6":
-  version: 0.5.16
-  resolution: "dom-accessibility-api@npm:0.5.16"
-  checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: c325b5144bb406df23f4affecffc117dbaec9af03daad9ee6b510c5be647b14d28ef0a4ea5ca06d696d8ab40bb777e5fed98b985976fdef9d8790178fa1d573f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Contributor's checklist:

### What I did

I've update the version of `@testing-library/jest-dom` for the security issue related to `@adobe/css-tools` security issue (https://github.com/advisories/GHSA-prr3-c3m5-p7q2) and related PR on the `jest-dom` https://github.com/testing-library/jest-dom/pull/555

### Change type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.2.4-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, specialdoom ([@specialdoom](https://github.com/specialdoom)), for all your work!
  
  #### 🐛 Bug Fix
  
  - Update `@testing-library/jest-dom` to latest [#52](https://github.com/storybookjs/jest/pull/52) ([@specialdoom](https://github.com/specialdoom))
  
  #### ⚠️ Pushed to `next`
  
  - Update README.md ([@ndelangen](https://github.com/ndelangen))
  
  #### Authors: 2
  
  - Norbert de Langen ([@ndelangen](https://github.com/ndelangen))
  - specialdoom ([@specialdoom](https://github.com/specialdoom))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
